### PR TITLE
Use system tinyxml if it's available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,6 @@ SET(SRC_SQUIDDIO
     src/pugiconfig.hpp
     src/Hyperlink.h
     src/gpxdocument.h
-    src/tinyxml.h
-    src/tinystr.h
     src/wxcurl/base.cpp
     src/wxcurl/dav.cpp
     src/wxcurl/davtool.cpp
@@ -140,7 +138,25 @@ SET(SRC_NMEA0183
     )
 INCLUDE_DIRECTORIES(nmea0183)
 
-ADD_LIBRARY(${PACKAGE_NAME} SHARED ${SRC_SQUIDDIO} ${SRC_NMEA0183})
+ADD_DEFINITIONS(-DTIXML_USE_STL)
+IF(UNIX)
+ INCLUDE("cmake/FindTinyXML.cmake")
+ FIND_PACKAGE(TinyXML QUIET)
+ENDIF(UNIX)
+
+IF(TINYXML_FOUND)
+ message (STATUS "Building with system tinyxml")
+ INCLUDE_DIRECTORIES(${TINYXML_INCLUDE_DIR})
+ ADD_LIBRARY(${PACKAGE_NAME} SHARED ${SRC_SQUIDDIO} ${SRC_NMEA0183})
+ TARGET_LINK_LIBRARIES(${PACKAGE_NAME} ${TINYXML_LIBRARIES} )
+ELSE(TINYXML_FOUND)
+ message (STATUS "Building with embedded tinyxml")
+ SET(SRC_LTINYXML
+    src/tinyxml.h
+    src/tinystr.h
+ )
+ ADD_LIBRARY(${PACKAGE_NAME} SHARED ${SRC_SQUIDDIO} ${SRC_NMEA0183} ${SRC_LTINYXML})
+ENDIF(TINYXML_FOUND)
 
 INCLUDE("cmake/PluginInstall.cmake")
 INCLUDE("cmake/PluginCurl.cmake")

--- a/cmake/FindTinyXML.cmake
+++ b/cmake/FindTinyXML.cmake
@@ -1,0 +1,26 @@
+# - Find TinyXML
+# Find the native TinyXML includes and library
+#
+#   TINYXML_FOUND       - True if TinyXML found.
+#   TINYXML_INCLUDE_DIR - where to find tinyxml.h, etc.
+#   TINYXML_LIBRARIES   - List of libraries when using TinyXML.
+#
+
+IF( TINYXML_INCLUDE_DIR )
+    # Already in cache, be silent
+    SET( TinyXML_FIND_QUIETLY TRUE )
+ENDIF( TINYXML_INCLUDE_DIR )
+
+FIND_PATH( TINYXML_INCLUDE_DIR "tinyxml.h"
+           PATH_SUFFIXES "tinyxml" )
+
+FIND_LIBRARY( TINYXML_LIBRARIES
+              NAMES "tinyxml"
+              PATH_SUFFIXES "tinyxml" )
+
+# handle the QUIETLY and REQUIRED arguments and set TINYXML_FOUND to TRUE if
+# all listed variables are TRUE
+INCLUDE( "FindPackageHandleStandardArgs" )
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( "TinyXML" DEFAULT_MSG TINYXML_INCLUDE_DIR TINYXML_LIBRARIES )
+
+MARK_AS_ADVANCED( TINYXML_INCLUDE_DIR TINYXML_LIBRARIES )


### PR DESCRIPTION
I'm packaging your plugin for Fedora & EPEL.

This patch enable use of the system tinyxml package.