### PR TITLE
plugin.xml.in: Fix copy-paste error.

### DIFF
--- a/squiddio-plugin.xml.in
+++ b/squiddio-plugin.xml.in
@@ -8,7 +8,7 @@
   <api-version> ${PKG_API_VERSION} </api-version>
   <open-source> no </open-source>
   <author> ${PKG_AUTHOR} </author>
-  <source> https://github.com/opencpn-radar-pi/radar_pi </source>
+  <source> https://github.com/mauroc/squiddio_pi </source>
 
   <description>
 Squiddio Plugin makes its global user-sourced and user-maintained


### PR DESCRIPTION
As heading says: Fix a silly copy-paste error. The xml stanza ins just informative and should not break any eggs. But it should be correct.