### PR TITLE
fix mkdir conditional

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,8 +34,7 @@ install:
 
 before_build:
   - cd c:\project\squiddio_pi
-  - mkdir build
-  - cd build
+  - rm -rf build && mkdir build && cd build  
   - ps: Start-FileDownload https://downloads.sourceforge.net/project/opencpnplugins/opencpn_lib/4.99.1405-vc141_xp/opencpn.lib
   - ps: Start-FileDownload http://opencpn.navnux.org/build_deps/OpenCPN_buildwin-4.99a.7z
   - cmd: 7z x -y OpenCPN_buildwin-4.99a.7z -oc:\project\squiddio_pi\buildwin
@@ -53,7 +52,7 @@ deploy:
 
   provider: GitHub
   auth_token: 
-    secure: 4l9NTrQyvKVqzBPAT3ejCSZhllJXWaI/QcFWTBHueU3YEqLRAZM3+LinoOBnMcf2
+    secure: 4l9NTrQyvKVqzBPAT3ejCSZhllJXWaI/QcFWTBHueU3YEqLRAZM3+LinoOBnMcf2  #Mauro's encryption
   artifact: installer,portable
   draft: true
   prerelease: true


### PR DESCRIPTION
Prevent appveyor failures when "build" dir exists or does not exist while setting up Appveyor to compile.
Earlier PR was from my master, which is not recommended, so I made a new branch and made the PR from that.