### PR TITLE
ci: macos: fix broken ruby (github deployment fix).

### DIFF
--- a/ci/travis-build-osx.sh
+++ b/ci/travis-build-osx.sh
@@ -32,4 +32,5 @@ cmake -DOCPN_CI_BUILD=$CI_BUILD \
   ..
 make -sj2
 make package
+rm -rf /usr/local/lib/ruby/gems/ && brew reinstall ruby
 chmod 644 /usr/local/lib/lib*.dylib


### PR DESCRIPTION
Simple, untested fix for the macos deployment failure.

Closes: #50 

In the long run I see no advantage i having multiple builds running. The circleci and travis builders basically produces the same artifacts, the difference is the deployment. So, merging this to fewer builders is probably a low hanging fruit. This needs a separate bug to be discussed in.