### PR TITLE
ci: circleci, appveyor: Only deploy on master branch (#52).

### DIFF
--- a/ci/appveyor-upload.sh
+++ b/ci/appveyor-upload.sh
@@ -6,6 +6,12 @@
 
 REPO='mauro-calvi/squiddio-pi'
 
+branch=$(git symbolic-ref --short HEAD)
+if [ "$branch" != 'master' ]; then
+    echo "Not on master branch, skipping deployment."
+    exit 0
+fi
+
 if [ -z "$CLOUDSMITH_API_KEY" ]; then
     echo 'Cannot deploy to cloudsmith, missing $CLOUDSMITH_API_KEY'
     exit 0

--- a/ci/circleci-upload.sh
+++ b/ci/circleci-upload.sh
@@ -11,6 +11,12 @@ if [ -z "$CIRCLECI" ]; then
     exit 0;
 fi
 
+branch=$(git symbolic-ref --short HEAD)
+if [ "$branch" != 'master' ]; then
+    echo "Not on master branch, skipping deployment."
+    exit 0
+fi
+
 if [ -z "$CLOUDSMITH_API_KEY" ]; then
     echo 'Cannot deploy to cloudsmith, missing $CLOUDSMITH_API_KEY'
     exit 0


### PR DESCRIPTION
Closes #52 so that PR builds successfully without making a failed deployment attempt.