### PR TITLE
Macos fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,9 @@ deploy:
   api_key:
     secure: "fAXQOEZd83GYDVDw+KOHEJwKWAD/ILVlT9vWl6FNQkjltIBVp0PpbkgRr/fQcGrQno7UMUZdPm+OIbWAq+0d675SoeZ8NFjGd884SzjslWauB8kRG7iK72Y0EAYqRHl83XqdspuCcBE24fU95C87DbQdhp/zmKi+NB8n3m0X4ifw2G6CNpUdaj9Oxq7dDIQikUTynmmIlTMXtNLr8aQRBihLVpMoIuWLyjskyxPuRU+jFkM0xAeyqy246ZFg0eK2HTIqhlSA/HJHlPHF0gBDxnjca5ZIGYC7s5rr03ghSIMAr6nLHCmAelWPp3+znwTzJ5mGv+4vKwOvOi3EMpCDtsDbh0ybMkSr3tdJzJ9TEsgZ6MIqC2X9bwKtQcW/cmSeJmmpUVhaIZ7KjYS3cIxlQ+jU0aIZupsf0P73rovTfNWuC919H9Ggu/Mc3rELwBUZ1FctxDFZ13cM1gnpbAZXA0xZGGK0AV3Y9M1BQ/RBcnez2OT7DAwYofYe2VAnvMJbYkJUKVVMsKZqPF+9fXGYhtVTpKw3j89nE98xRkIKiWQBmUE6x5XPSgxsI1CaDBIuZiXDO/IMh2v3HGiFlOC8qAuV6Z1vdHbaIFtzPkVEZ1miMBbD3XPki3Crl4kVXtGrCPAl6uH3YVrats9CL6shfgwzsS52zBacQxQu7RCrT6U="
   file_glob: true
-  file: "$TRAVIS_BUILD_DIR/build/*.{deb,rpm,dmg,txz,pkg,pkg.tar.xz}"
+  file: "$TRAVIS_BUILD_DIR/build/*.{deb,pkg}"
   skip_cleanup: true
   on:
     repo: mauroc/squiddio_pi
     tags: true
     all_branches: true
-    

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -4,24 +4,37 @@
 # Build the  MacOS artifacts 
 #
 
+# Fix broken ruby on the CircleCI image:
+if [ -n "$CI" ]; then
+    curl -fsSL \
+        https://raw.githubusercontent.com/Homebrew/install/master/uninstall \
+        > uninstall
+    chmod 755 uninstall
+    ./uninstall -f
+    inst="https://raw.githubusercontent.com/Homebrew/install/master/install"
+    /usr/bin/ruby -e "$(curl -fsSL $inst)"
+fi
+
+
 set -xe
 
+set -o pipefail
 for pkg in cairo libexif xz libarchive python3 wget cmake; do
-    brew list $pkg 2>&1 >/dev/null || brew install $pkg
+    brew list $pkg 2>/dev/null | head -10 || brew install $pkg
 done
 
-wget http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz
+wget -q http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz
 tar xJf wx312_opencpn50_macos109.tar.xz -C /tmp
 export PATH="/usr/local/opt/gettext/bin:$PATH"
 echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.bash_profile
  
 rm -rf build && mkdir build && cd build
 test -z "$TRAVIS_TAG" && CI_BUILD=OFF || CI_BUILD=ON
-cmake -DOCPN_CI_BUILD=$CI_BUILD \
-  -DOCPN_USE_LIBCPP=ON \
+cmake \
   -DwxWidgets_CONFIG_EXECUTABLE=/tmp/wx312_opencpn50_macos109/bin/wx-config \
   -DwxWidgets_CONFIG_OPTIONS="--prefix=/tmp/wx312_opencpn50_macos109" \
-  -DCMAKE_INSTALL_PREFIX=/tmp/opencpn -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+  -DCMAKE_INSTALL_PREFIX=/tmp/opencpn \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
   ..
 make -sj2
 make package

--- a/ci/travis-build-osx.sh
+++ b/ci/travis-build-osx.sh
@@ -32,5 +32,12 @@ cmake -DOCPN_CI_BUILD=$CI_BUILD \
   ..
 make -sj2
 make package
+
+make install
+wget http://opencpn.navnux.org/build_deps/Packages.dmg;
+hdiutil attach Packages.dmg;
+sudo installer -pkg "/Volumes/Packages 1.2.5/Install Packages.pkg" -target "/"
+make create-pkg
+
+ls -l *.pkg *.tar.gz *.xml
 rm -rf /usr/local/lib/ruby/gems/ && brew reinstall ruby
-chmod 644 /usr/local/lib/lib*.dylib

--- a/ci/travis-build-osx.sh
+++ b/ci/travis-build-osx.sh
@@ -6,15 +6,20 @@
 
 # As of travis-ci-macos-10.13-xcode9.4.1-1529955246, the travis osx image
 # contains a broken homebrew. Walk-around by reinstalling:
-curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > uninstall
-chmod 755 uninstall
-./uninstall -f
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" 
+if [ -n "$TRAVIS" ]; then
+    curl -fsSL \
+        https://raw.githubusercontent.com/Homebrew/install/master/uninstall \
+        > uninstall
+    chmod 755 uninstall
+    ./uninstall -f
+    inst="https://raw.githubusercontent.com/Homebrew/install/master/install"
+    /usr/bin/ruby -e "$(curl -fsSL $inst)"
+fi
 
 # bailout on errors and echo commands
 set -xe
-set -o pipefail
 
+set -o pipefail
 for pkg in cairo cmake libarchive libexif python3 wget xz; do
     brew list $pkg 2>/dev/null | head -10 || brew install $pkg
 done
@@ -47,4 +52,6 @@ ls -l *.pkg *.tar.gz *.xml
 # As of travis-ci-macos-10.13-xcode9.4.1-1529955246, the travis osx image
 # contains a broken ruby setup used by deployment code. Walk around by
 # reinstalling:
-rm -rf /usr/local/lib/ruby/gems/ && brew reinstall ruby
+if [ -n "$TRAVIS" ]; then
+    rm -rf /usr/local/lib/ruby/gems/ && brew reinstall ruby
+fi

--- a/ci/travis-build-osx.sh
+++ b/ci/travis-build-osx.sh
@@ -13,9 +13,10 @@ chmod 755 uninstall
 
 # bailout on errors and echo commands
 set -xe
+set -o pipefail
 
 for pkg in cairo cmake libarchive libexif python3 wget xz; do
-    brew list $pkg || brew install $pkg
+    brew list $pkg 2>/dev/null | head -10 || brew install $pkg
 done
 curl --version >/dev/null || brew install curl
 wget http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz

--- a/ci/travis-build-osx.sh
+++ b/ci/travis-build-osx.sh
@@ -4,12 +4,14 @@
 # Build the Travis OSX artifacts 
 #
 
-# bailout on errors and echo commands
+# As of travis-ci-macos-10.13-xcode9.4.1-1529955246, the travis osx image
+# contains a broken homebrew. Walk-around by reinstalling:
 curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > uninstall
 chmod 755 uninstall
 ./uninstall -f
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" 
 
+# bailout on errors and echo commands
 set -xe
 
 for pkg in cairo cmake libarchive libexif python3 wget xz; do
@@ -40,4 +42,8 @@ sudo installer -pkg "/Volumes/Packages 1.2.5/Install Packages.pkg" -target "/"
 make create-pkg
 
 ls -l *.pkg *.tar.gz *.xml
+
+# As of travis-ci-macos-10.13-xcode9.4.1-1529955246, the travis osx image
+# contains a broken ruby setup used by deployment code. Walk around by
+# reinstalling:
 rm -rf /usr/local/lib/ruby/gems/ && brew reinstall ruby

--- a/ci/travis-build-osx.sh
+++ b/ci/travis-build-osx.sh
@@ -20,31 +20,29 @@ fi
 set -xe
 
 set -o pipefail
-for pkg in cairo cmake libarchive libexif python3 wget xz; do
+for pkg in cairo cmake curl libarchive libexif python3 wget xz; do
     brew list $pkg 2>/dev/null | head -10 || brew install $pkg
 done
-curl --version >/dev/null || brew install curl
-wget http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz
+
+wget -q http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz
 tar xJf wx312_opencpn50_macos109.tar.xz -C /tmp
 export PATH="/usr/local/opt/gettext/bin:$PATH"
 echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.bash_profile
 
-mkdir  build
-cd build
-test -z "$TRAVIS_TAG" && CI_BUILD=OFF || CI_BUILD=ON
-cmake -DOCPN_CI_BUILD=$CI_BUILD \
-  -DOCPN_USE_LIBCPP=ON \
+mkdir build && cd build
+cmake  \
   -DwxWidgets_CONFIG_EXECUTABLE=/tmp/wx312_opencpn50_macos109/bin/wx-config \
   -DwxWidgets_CONFIG_OPTIONS="--prefix=/tmp/wx312_opencpn50_macos109" \
-  -DCMAKE_INSTALL_PREFIX=/tmp/opencpn -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+  -DCMAKE_INSTALL_PREFIX=/tmp/opencpn \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
   ..
 make -sj2
 make package
 
-make install
-wget http://opencpn.navnux.org/build_deps/Packages.dmg;
-hdiutil attach Packages.dmg;
+wget -q http://opencpn.navnux.org/build_deps/Packages.dmg
+hdiutil attach Packages.dmg
 sudo installer -pkg "/Volumes/Packages 1.2.5/Install Packages.pkg" -target "/"
+make install
 make create-pkg
 
 ls -l *.pkg *.tar.gz *.xml


### PR DESCRIPTION
More cleanup of the macos builders:

  - Restore the package generation -- build .pkg package in travis. Closes: #55 
  - Conditionalize travis fixes -- Closes: #56
  - Cleanup of parts writing clutter into the logs.
  - Various cleanup and comments.