### PR TITLE
ci: appveyor-upload: Fix missing git HEAD (#61)

### DIFF
--- a/ci/appveyor-upload.sh
+++ b/ci/appveyor-upload.sh
@@ -6,8 +6,7 @@
 
 REPO='mauro-calvi/squiddio-pi'
 
-branch=$(git symbolic-ref --short HEAD)
-if [ "$branch" != 'master' ]; then
+if [ "$(git rev-parse master)" != "$(git rev-parse HEAD)" ]; then
     echo "Not on master branch, skipping deployment."
     exit 0
 fi


### PR DESCRIPTION
Patch as from #61, partly tested by @rgleason. Since this is about deployment the final tests must by done by the maintainer.

Closes: #61