### PR TITLE
ci: cloudsmith: Use stable repo for tagged commits.

### DIFF
--- a/ci/appveyor-upload.sh
+++ b/ci/appveyor-upload.sh
@@ -40,11 +40,13 @@ source ../build/pkg_version.sh
 test -n "$tag" && VERSION="$tag" || VERSION="${VERSION}+${BUILD_ID}.${commit}"
 test -n "$tag" && REPO="$STABLE_REPO" || REPO="$UNSTABLE_REPO"
 
-# There is no sed available in git bash. This is nasty, but seems
-# to work:
-while read line; do
-    echo ${line/squiddio-pi/squiddo-stable}
-done < $xml > xml.tmp && cp xml.tmp $xml && rm xml.tmp
+if [ -n "$tag" ]; then
+    # There is no sed available in git bash. This is nasty, but seems
+    # to work:
+    while read line; do
+        echo ${line/squiddio-pi/squiddo-stable}
+    done < $xml > xml.tmp && cp xml.tmp $xml && rm xml.tmp
+fi
 
 cloudsmith push raw \
     --republish \

--- a/ci/appveyor-upload.sh
+++ b/ci/appveyor-upload.sh
@@ -44,7 +44,7 @@ if [ -n "$tag" ]; then
     # There is no sed available in git bash. This is nasty, but seems
     # to work:
     while read line; do
-        echo ${line/squiddio-pi/squiddo-stable}
+        echo ${line/squiddio-pi/squiddio-stable}
     done < $xml > xml.tmp && cp xml.tmp $xml && rm xml.tmp
 fi
 

--- a/ci/circleci-upload.sh
+++ b/ci/circleci-upload.sh
@@ -14,7 +14,7 @@
 
 set -xe
 
-STABLE_REPO=${CLOUDSMITH_STABLE_REPO:-'mauro-calvi/squiddio-pi'}
+STABLE_REPO=${CLOUDSMITH_STABLE_REPO:-'mauro-calvi/squiddio-stable'}
 UNSTABLE_REPO=${CLOUDSMITH_UNSTABLE_REPO:-'mauro-calvi/squiddio-pi'}
 
 if [ -z "$CIRCLECI" ]; then


### PR DESCRIPTION
Add definition of new stable repo to circleci upload. Likewise
for appveyor, which also is updated to provide some metadata
on uploads (similar to circleci uploads). This means that tagged
releases will be directed to the stable repo.

This only affects installer artifacts: tarball and xml metadata.

Final tests must be done by maintainer. I have tested locally as possible.