### PR TITLE
Issue 96: Fix broken tarball URL in metadata.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,14 +73,17 @@ SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "" "Debug" "Release" "RelWi
 MESSAGE (STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 SET(PKG_NVR ${PACKAGE_NAME}-${PROJECT_VERSION}-${OCPN_MIN_VERSION}-${OCPN_API_VERSION_MAJOR}.${OCPN_API_VERSION_MINOR})
-SET(PKG_BASE_URL "https://dl.cloudsmith.io/public/${CLOUDSMITH_USER}/${PACKAGE}-pi/raw/files")
 
 INCLUDE("cmake/PluginSetup.cmake")
 set(PLUGIN_NAME ${PACKAGE}-plugin-${PKG_TARGET}-${PKG_TARGET_VERSION})
 
 SET(PKG_RELEASE "1")
 SET(PKG_NVR ${PACKAGE_NAME}-${PACKAGE_VERSION}.${PKG_RELEASE})
-SET(PKG_BASE_URL "https://dl.cloudsmith.io/public/mauro-calvi/squiddio-pi/raw/files")
+
+# The @keyword@ references are patched to actual values by upload script.
+SET(TARBALL_URL "https://dl.cloudsmith.io/public/@pkg_repo@/raw")
+SET(TARBALL_URL ${TARBALL_URL}/names/@name@/versions/@version@/@filename@)
+
 
 
 INCLUDE("cmake/PluginSetup.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ SET(PKG_NVR ${PACKAGE_NAME}-${PROJECT_VERSION}-${OCPN_MIN_VERSION}-${OCPN_API_VE
 INCLUDE("cmake/PluginSetup.cmake")
 set(PLUGIN_NAME ${PACKAGE}-plugin-${PKG_TARGET}-${PKG_TARGET_VERSION})
 
-SET(PKG_RELEASE "1")
+SET(PKG_RELEASE "6")
 SET(PKG_NVR ${PACKAGE_NAME}-${PACKAGE_VERSION}.${PKG_RELEASE})
 
 # The @keyword@ references are patched to actual values by upload script.

--- a/ci/appveyor-upload.sh
+++ b/ci/appveyor-upload.sh
@@ -7,7 +7,8 @@
 STABLE_REPO=${CLOUDSMITH_STABLE_REPO:-'mauro-calvi/squiddio-stable'}
 UNSTABLE_REPO=${CLOUDSMITH_UNSTABLE_REPO:-'mauro-calvi/squiddio-pi'}
 
-if [ "$(git rev-parse master)" != "$(git rev-parse HEAD)" ]; then
+git_head=$(git rev-parse master) || git_head="unknown"
+if [ "$git_head" != "$(git rev-parse HEAD)" ]; then
     echo "Not on master branch, skipping deployment."
     exit 0
 fi

--- a/ci/appveyor-upload.sh
+++ b/ci/appveyor-upload.sh
@@ -33,33 +33,33 @@ BUILD_ID=${APPVEYOR_BUILD_NUMBER:-1}
 commit=$(git rev-parse --short=7 HEAD) || commit="unknown"
 tag=$(git tag --contains HEAD)
 
-tarball=$(ls *.tar.gz)
 xml=$(ls *.xml)
+tarball=$(ls *.tar.gz)
+tarball_basename=${tarball##*/}
 
 source ../build/pkg_version.sh
 test -n "$tag" && VERSION="$tag" || VERSION="${VERSION}+${BUILD_ID}.${commit}"
 test -n "$tag" && REPO="$STABLE_REPO" || REPO="$UNSTABLE_REPO"
+tarball_name=squiddio-${PKG_TARGET}-${PKG_TARGET_VERSION}-tarball
 
-if [ -n "$tag" ]; then
-    # There is no sed available in git bash. This is nasty, but seems
-    # to work:
-    while read line; do
-        echo ${line/squiddio-pi/squiddio-stable}
-    done < $xml > xml.tmp && cp xml.tmp $xml && rm xml.tmp
-fi
+# There is no sed available in git bash. This is nasty, but seems
+# to work:
+while read line; do
+    line=${line/@pkg_repo@/$REPO}
+    line=${line/@name@/$tarball_name}
+    line=${line/@version@/$VERSION}
+    line=${line/@filename@/$tarball_basename}
+    echo $line
+done < $xml > xml.tmp && cp xml.tmp $xml && rm xml.tmp
 
-cloudsmith push raw \
-    --republish \
-    --no-wait-for-sync \
+cloudsmith push raw --republish --no-wait-for-sync \
     --name squiddio-${PKG_TARGET}-${PKG_TARGET_VERSION}-metadata \
     --version ${VERSION} \
     --summary "squiddio opencpn plugin metadata for automatic installation" \
     $REPO $xml
 
-cloudsmith push raw  \
-    --republish \
-    --no-wait-for-sync \
-    --name squiddio-${PKG_TARGET}-${PKG_TARGET_VERSION}-tarball \
+cloudsmith push raw --republish --no-wait-for-sync \
+    --name $tarball_name \
     --version ${VERSION} \
     --summary "squiddio opencpn plugin tarball for automatic installation" \
     $REPO $tarball

--- a/ci/circleci-upload.sh
+++ b/ci/circleci-upload.sh
@@ -46,25 +46,28 @@ BUILD_ID=${CIRCLE_BUILD_NUM:-1}
 commit=$(git rev-parse --short=7 HEAD) || commit="unknown"
 tag=$(git tag --contains HEAD)
 
-tarball=$(ls $HOME/project/build/*.tar.gz)
 xml=$(ls $HOME/project/build/*.xml)
-test -z "$tag" || sudo sed -i -e "s|$UNSTABLE_REPO|$STABLE_REPO|" $xml
+tarball=$(ls $HOME/project/build/*.tar.gz)
+tarball_basename=${tarball##*/}
 
 source $HOME/project/build/pkg_version.sh
 test -n "$tag" && VERSION="$tag" || VERSION="${VERSION}+${BUILD_ID}.${commit}"
 test -n "$tag" && REPO="$STABLE_REPO" || REPO="$UNSTABLE_REPO"
+tarball_name=squiddio-${PKG_TARGET}-${PKG_TARGET_VERSION}-tarball
 
-cloudsmith push raw \
-    --republish \
-    --no-wait-for-sync \
+sudo sed -i -e "s|@pkg_repo@|$REPO|"  $xml
+sudo sed -i -e "s|@name@|$tarball_name|" $xml
+sudo sed -i -e "s|@version@|$VERSION|" $xml
+sudo sed -i -e "s|@filename@|$tarball_basename|" $xml
+
+cloudsmith push raw --republish --no-wait-for-sync \
     --name squiddio-${PKG_TARGET}-${PKG_TARGET_VERSION}-metadata \
     --version ${VERSION} \
     --summary "squiddio opencpn plugin metadata for automatic installation" \
     $REPO $xml
-cloudsmith push raw  \
-    --republish \
-    --no-wait-for-sync \
-    --name squiddio-${PKG_TARGET}-${PKG_TARGET_VERSION}-tarball \
+
+cloudsmith push raw --republish --no-wait-for-sync \
+    --name $tarball_name \
     --version ${VERSION} \
     --summary "squiddio opencpn plugin tarball for automatic installation" \
     $REPO $tarball

--- a/squiddio-plugin.xml.in
+++ b/squiddio-plugin.xml.in
@@ -19,8 +19,6 @@ Android comes with sQuiddio built in.
 
   <target>${PKG_TARGET}</target>
   <target-version>${PKG_TARGET_VERSION}</target-version>
-  <tarball-url>
-    ${PKG_BASE_URL}/${PKG_NVR}_${PKG_TARGET_NVR}.tar.gz
-  </tarball-url>
+  <tarball-url> ${TARBALL_URL} </tarball-url>
   <info-url> https://opencpn.org/OpenCPN/plugins/sQuiddio.html </info-url>
 </opencpn-plugin>


### PR DESCRIPTION
Bugfix PR, but also a major cleanup of the code handling the tarball URl metadata. The previous code which just edited the xml file without any notice was a hack.